### PR TITLE
Fix reorder quantity when stock is low

### DIFF
--- a/src/InkopModul.js
+++ b/src/InkopModul.js
@@ -130,7 +130,16 @@ function InkopModul() {
     const periodDays = getPeriodDays();
     const avgDailySales = totalSales / periodDays;
     const adjustedDailySales = avgDailySales * (salesAdjustment / 100);
-    const requiredStock = adjustedDailySales * (deliveryTime + desiredCoverageDays);
+
+    // Hur många dagar av leveranstiden klarar vi av med nuvarande lager?
+    const daysCoverable = adjustedDailySales > 0 ? currentStock / adjustedDailySales : 0;
+
+    // Räkna endast med de dagar då vi faktiskt kan sälja under leveranstiden
+    const effectiveLeadTime = Math.min(deliveryTime, daysCoverable);
+
+    // Lagerbehov vid leverans bortser från försäljning under dagar då lagret är slut
+    const requiredStock = adjustedDailySales * (effectiveLeadTime + desiredCoverageDays);
+
     const reorderQty = Math.max(0, Math.ceil(requiredStock - (currentStock || 0)));
     return { reorderQty, avgDailySales, adjustedDailySales };
   };


### PR DESCRIPTION
## Summary
- adjust reorder quantity logic in `InkopModul` and `SkapaInkopsOrder` to ignore sales during periods of expected stockout

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*