### PR TITLE
Fix reorder quantity logic

### DIFF
--- a/src/InkopModul.js
+++ b/src/InkopModul.js
@@ -131,16 +131,17 @@ function InkopModul() {
     const avgDailySales = totalSales / periodDays;
     const adjustedDailySales = avgDailySales * (salesAdjustment / 100);
 
-    // Hur många dagar av leveranstiden klarar vi av med nuvarande lager?
-    const daysCoverable = adjustedDailySales > 0 ? currentStock / adjustedDailySales : 0;
+    // Beräkna hur mycket lager som förväntas finnas kvar när ordern anländer
+    const remainingStockAtDelivery = currentStock - adjustedDailySales * deliveryTime;
 
-    // Räkna endast med de dagar då vi faktiskt kan sälja under leveranstiden
-    const effectiveLeadTime = Math.min(deliveryTime, daysCoverable);
+    // Lagerbehovet när ordern anländer baseras på hela leveranstiden och önskad täckning
+    const requiredStock = adjustedDailySales * (deliveryTime + desiredCoverageDays);
 
-    // Lagerbehov vid leverans bortser från försäljning under dagar då lagret är slut
-    const requiredStock = adjustedDailySales * (effectiveLeadTime + desiredCoverageDays);
-
-    const reorderQty = Math.max(0, Math.ceil(requiredStock - (currentStock || 0)));
+    // Dra endast av det lager som faktiskt finns kvar när ordern kommer
+    const reorderQty = Math.max(
+      0,
+      Math.ceil(requiredStock - Math.max(remainingStockAtDelivery, 0))
+    );
     return { reorderQty, avgDailySales, adjustedDailySales };
   };
 

--- a/src/SkapaInkopsOrder.js
+++ b/src/SkapaInkopsOrder.js
@@ -432,18 +432,17 @@ function SkapaInkopsOrder({ onOrderSaved }) {
     // Applicera tillväxtprocent på genomsnittlig daglig försäljning
     const adjustedAvgDailySales = avgDailySales * (1 + growthPercentage / 100);
 
-    // Hur många dagar av leveranstiden kan nuvarande lager täcka?
-    const daysCoverable = adjustedAvgDailySales > 0 ? currentStock / adjustedAvgDailySales : 0;
+    // Hur mycket lager förväntas finnas kvar när ordern anländer?
+    const remainingStockAtDelivery = currentStock - adjustedAvgDailySales * deliveryTime;
 
-    // Om lagret inte räcker hela leveranstiden, räkna bara med den del vi kan sälja
-    const effectiveLeadTime = Math.min(deliveryTime, daysCoverable);
+    // Lagerbehov när ordern anländer baserat på hela leveranstiden och säkerhetslager
+    const requiredStock = adjustedAvgDailySales * (deliveryTime + safetyStock);
 
-    // Beräkna hur mycket lager vi vill ha när ordern anländer
-    // Vi bortser från försäljning under de dagar vi saknar lager
-    const requiredStock = adjustedAvgDailySales * (effectiveLeadTime + safetyStock);
-
-    // Ta hänsyn till nuvarande lager och inkommande kvantiteter
-    const reorderQty = Math.max(0, Math.ceil(requiredStock - (currentStock || 0) - (incomingQty || 0)));
+    // Dra bara av lager som finns kvar samt inkommande kvantiteter
+    const reorderQty = Math.max(
+      0,
+      Math.ceil(requiredStock - Math.max(remainingStockAtDelivery, 0) - (incomingQty || 0))
+    );
 
     return { reorderQty, avgDailySales };
   };
@@ -1229,7 +1228,7 @@ function SkapaInkopsOrder({ onOrderSaved }) {
                   <TableCell align="right">{Math.round(item.currentStock)}</TableCell>
                   <TableCell align="right">{item.incomingQty}</TableCell>
                   <TableCell align="right">{item.totalSales}</TableCell>
-                  <TableCell align="right">{item.avgDailySales.toFixed(1)}</TableCell>
+                  <TableCell align="right">{item.avgDailySales.toFixed(2)}</TableCell>
                   <TableCell align="right">
                     <TextField
                       variant="outlined"


### PR DESCRIPTION
## Summary
- compute reorder quantity using entire lead time
- subtract only stock remaining at delivery instead of the whole stock

## Testing
- `npm test --silent` *(fails: react-scripts not found)*